### PR TITLE
[41기 김상헌] 로그인/회원가입 페이지 버그 수정 및 알림창 추가 구현

### DIFF
--- a/src/pages/Login/User/TextInput/TextInput.js
+++ b/src/pages/Login/User/TextInput/TextInput.js
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
 import './TextInput.scss';
 
 export default function TextInput({
@@ -10,10 +11,15 @@ export default function TextInput({
   setPasswordType,
   validCondition,
 }) {
+  const location = useLocation();
   const [isLabelMove, setIsLabelMove] = useState(false);
   const [isError, setIsError] = useState(false);
 
   const isErrorCondition = !validCondition[`${name}`] && inputValue !== '';
+
+  useEffect(() => {
+    setIsLabelMove(false);
+  }, [location.pathname]);
 
   const handleInpChange = e => {
     const { name, value } = e.target;

--- a/src/pages/Login/User/User.js
+++ b/src/pages/Login/User/User.js
@@ -67,10 +67,12 @@ export default function User({ title, children }) {
         .then(data => {
           console.log(data);
           if (title === '회원가입') {
+            alert('회원가입이 완료되었습니다!');
             setUserInfo(initialUserInfo);
             navigate('/login');
           }
           if (data.accessToken) {
+            alert('로그인이 완료되었습니다!');
             localStorage.setItem('accessToken', data.accessToken);
             navigate('/');
           }


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 
- 로그인 및 회원가입시 알림창 구현
- 회원가입 완료시 로그인 input label 원위치되지 않는 버그 수정

<br />

## :: 구현 사항 설명 
1. 로그인 및 회원가입시 알림창 구현
- fetch 완료 후 로그인/회원가입 조건에 따라 alert창을 다르게 띄워줌

2. 회원가입 완료시 로그인 input label 원위치되지 않는 버그 수정
- 회원가입이 완료되는 경우 pathname이 `/signup` -> `/login` 으로 변경되기에
`<TextInput />` 컴포넌트에 useEffect로  location.pathname이 변경되는 경우 `isLabelMove`이 기본값(`false`)으로 변경되도록 설정

<br />

## :: 성장 포인트 
- 사용자가 사이트를 이용하며 마주할 수 있는 디테일한 상황에 대해 조금 더 고려하게 되었습니다.
