### PR TITLE
Modify : Nav Bar 최신화

### DIFF
--- a/src/components/NavBar/MaterialsCate/MaterialsCate.js
+++ b/src/components/NavBar/MaterialsCate/MaterialsCate.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import './MaterialsCate.scss';
 
 export default function MaterialsCate({ menuTabClose }) {

--- a/src/components/NavBar/NavBar.js
+++ b/src/components/NavBar/NavBar.js
@@ -1,6 +1,5 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link, useNavigate, useLocation } from 'react-router-dom';
-import { useState } from 'react';
 import PlantsCate from './PlantsCate/PlantsCate';
 import MaterialsCate from './MaterialsCate/MaterialsCate';
 import Search from './Search/Search';
@@ -11,11 +10,8 @@ export default function NavBar() {
   const [closeBtn, setCloseBtn] = useState('closeBtn');
   const [contentsNull, setContentsNull] = useState('contentsNull');
   const [isLoggedIn, setIsLoggedIn] = useState(false);
-  const location = useLocation();
 
-  useEffect(() => {
-    menuTabClose();
-  }, [location]);
+  const location = useLocation;
 
   useEffect(() => {
     isLogin();
@@ -59,7 +55,10 @@ export default function NavBar() {
           </li>
         ))}
       </ul>
-      <div className={contentsNull}>{MAPPING_OBJ[currentTab]}</div>
+      <div className={contentsNull}>
+        {MAPPING_OBJ[currentTab] &&
+          MAPPING_OBJ[currentTab](menuTabClose, closeBtn)}
+      </div>
       <div className={closeBtn} onClick={menuTabClose}>
         닫기
         <img src="/images/nav/close_btn.png" alt="close_Btn" />
@@ -77,7 +76,9 @@ export default function NavBar() {
 const TAB_ARR = ['Plants', 'Materials', 'Search'];
 
 const MAPPING_OBJ = {
-  Plants: <PlantsCate />,
-  Materials: <MaterialsCate />,
-  Search: <Search />,
+  Plants: menuTabClose => <PlantsCate menuTabClose={menuTabClose} />,
+  Materials: menuTabClose => <MaterialsCate menuTabClose={menuTabClose} />,
+  Search: (menuTabClose, closeBtn) => (
+    <Search menuTabClose={menuTabClose} closeBtn={closeBtn} />
+  ),
 };

--- a/src/components/NavBar/PlantsCate/PlantsCate.js
+++ b/src/components/NavBar/PlantsCate/PlantsCate.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import './PlantsCate.scss';
 
 export default function PlantsCate({ menuTabClose }) {

--- a/src/components/NavBar/Search/Search.js
+++ b/src/components/NavBar/Search/Search.js
@@ -83,11 +83,6 @@ export default function Search({ menuTabClose, closeBtn }) {
         </div>
       </div>
       <SearchResult plantResult={plantResult} searchValue={searchValue} />
-      {/* <div className="menuImage">
-        <div className="searchImage">
-          <img src="/images/nav/search_img.jpg" alt="search_img" />
-        </div>
-      </div> */}
     </div>
   );
 }


### PR DESCRIPTION
## :: 최근 작업 주제
- [x] 레이아웃 추가
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정
<br />

## :: 구현 목표
1. Nav Bar 레이아웃 구현
2. MenuList 레이아웃 구현
3. Nav Bar 및 MenuList 기능 구현 (Menu Tab 기능)
4. Nav Bar 내 Login/Logout 상태 반영 기능 구현
5. MenuList 애니메이션 기능 구현
6. MenuList 링크 기능 구현 (쿼리 스트링 사용)
7. Search 레이아웃 구현
8. Search 기능 구현
<br />

## :: 구현 사항 설명
1. Nav Bar 레이아웃 구현
- 대표 상품 카테고리 (Plants, Materials) 탭 생성
- 추가 구현 사항 고려하여 Search 탭과 Archive 탭 생성
- navBar position: fixed; z-index: 100; 설정함
<br />

2. MenuList 구현
- 상수 데이터와 map 메서드 이용하여 대분류 (BIG_CATE_MENU) 와 중분류 (CATE_MENU) 를 MenuList 에 추가
- 카테고리 타이틀 ('카테고리', '위치', '분위기', '크기', '난이도') 과 카테고리 아이템 두 가지 모두  map 메서드를 이용해서 MenuList 에 추가하기 위해 이중으로 map 을 사용
- 중분류 리스트 정렬을 위해 flex-wrap: wrap 사용 / categoryList 의 width 를 50% 으로 설정함
- 메뉴 탭 클릭 시 navBar 아래에 위치시키기 위해 position: absolute; top: 80px; (navBar height) 설정함
<br />

3. Nav Bar 및 MenuList 기능 구현 (Menu Tab 기능)
- westudy 참고하여 메뉴 탭 배열 생성 (TAB_ARR = ['Plants', 'Materials', 'Search'] 후 map 메서드와 useState 를 사용하여 기능 구현
- 메뉴 탭 클릭 시 해당 탭의 컴포넌트를 렌더링 (MAPPING_OBJ)
- 메뉴 탭 클릭 시 닫기 버튼 생성 / useState 를 이용하여 닫기 버튼의 className 을 closeBtn (display: none) 에서 closeBtnShow 로 변경함
- 닫기 버튼 클릭 시 탭이 닫히면서 닫기 버튼도 같이 사라짐 / useState 를 이용하여 메뉴 탭 클릭 시 컴포넌트를 렌더링했던 부분의 className 을 contents 에서 contentsNull (display: none) 으로 변경, 닫기 버튼의 className 을 다시 classBtn 으로 변경함
- 이후 다시 메뉴 탭을 클릭했을 때 contents 에 컴포넌트가 렌더링 될 수 있도록 메뉴 탭 클릭 시 항상 className 이 contents 로 변경 (초기화) 될 수 있도록 설정함
- 카테고리 클릭 시 해당 링크로 이동하면서 메뉴 탭이 닫혀야 함 / useLocation 을 사용하여 location 의 key 가 바뀌면 menuTabClose 함수 호출 (useEffect 사용)
<br />

4. Nav Bar 내 Login/Logout 상태 반영 기능 구현
- isLoggedIn state 를 만들어서 상태 관리 / true 일 때 Logout, false 일 때 Login 렌더링
- isLogin 함수로 local storage 에 accessToken 이 있는지 확인 / accessToken 이 있으면 isLoggedIn 를 true 로 변경 / useEffect 로 isLogin 호출
- handleLoginClick 함수: isLoggedIn 이 true 일 때 (로그인 된 상태) Logout 버튼을 누르면 Login 버튼에 걸려있는 기존 이벤트 (로그인 페이지로 이동) 를 막고 (e.preventDefault()), isLoggedIn state 를 false 로 바꾸고, local storage 의 accessToken 을 삭제함
<br />

5. MenuList 애니메이션 기능 구현
- keyframes 생성, animation-name 과 animation-duration 설정하여 MenuList 가 펼쳐질 때 애니메이션 적용
<br />

6. MenuList 링크 기능 구현 (쿼리 스트링 사용)
- 쿼리 스트링을 MenuList 에 있는 카테고리 링크와 연결하기 위해 기존의 상수 데이터 배열을 수정함 (categoryItems 의 value 로 있던 배열 안에 객체로 title 과 url 을 추가함)
<br />

7. Search 레이아웃 구현
- 좌측의 searchLeftBox 에 input, 우측에는 SearchResult 컴포넌트를 위치시켜 검색 결과가 렌더링함
- closeBtn 을 props 로 넘겨 받아 goBlank 함수에서 사용 / closeBtn 이 'closeBtn' 인 경우 쿼리 스트링 reset
<br />

8. Search 기능 구현
- input 에 검색 키워드가 입력될 때마다 (onChange) e.target.value 가 searchValue 에 저장 / searchParams.set ('search', e.target.value) 로 쿼리 스트링을 변경함
- 검색 결과는 searchValue 가 공백일 때 보이지 않도록 isNull 함수를 사용
- 검색 결과가 2개씩 보여지도록 flex-wrap: wrap 사용
- 상수 데이터를 활용한 검색 기능 구현 완료 / API 통신 예정
<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등)
- flex-wrap: wrap 과 width 설정 (33%) 을 사용하여 리스트가 5개인 경우 3개 / 2개로 깔끔하게 정렬할 수 있음
- MenuList 구현으로 이중으로 map 메서드를 사용할 수 있게 됨
- 배열 내 객체로 map 메서드를 사용하는 것뿐만 아니라, 배열 속의 객체 속의 배열 (객체 내 value 가 배열인 경우 / {id: 1, title: '위치', categoryItems: ['Houseplant', 'Hanging', 'Desk', 'Window', 'Outdoor'] 에서 categoryItems 에 접근하여 map 메서드 이용 / categoryItems.map) 에 접근하여 map 메서드를 사용할 수 있게 됨
- {.map} 이 시작하는 곳이 depth 시작하는 곳 (return문으로 새로 생성되는 부분이 {.map} 시작 위치에 생성됨)
- 상수 데이터는 맨 아래 위치하는 것이 컨벤션
- 구조 분해 할당
```
{BIG_CATE_MENU.map(bigCategory => {
   const { id, title, categoryItems } = bigCategory;

{BIG_CATE_MENU.map(({ id, title, categoryItems }) => {
으로 줄일 수 있음
```
-  MenuList 가 렌더링되는 div (contents) 가 구조상 navBar 에 종속되므로 height 를 100% 을 주면 navBar height 와 같아짐 / 화면에 딱 맞는 크기로 렌더링하려면 height 에 100vh 를 줘야 함
- 로직이 꼬일수록 간단하게 생각하기
- 값이 true 일 때뿐만 아니라 'accessToken 이 있으면' 을 'accessToken &&' 으로 쓸 수 있음
- && 연산자를 사용할 때는 한번에 여러가지 동작을 실행시킬 수 없음 / 한 가지씩 나눠서 써야 함
- {isLoggedIn ? 'Logout' : 'Login'}
- z-index 는 숫자가 높을 수록 위에 렌더링 됨
- Link 랑 onClick 같이 쓰지 않기
- searchParams.set 했을 때 key 가 다르면 기존 쿼리 스트링에 추가됨 / navigate 이용하기
- useState 사용할 때는 초기값 확인! 빈 배열에서 replace(' ', '') 불가능 / 초기값을 useStat('') 으로 설정
- 한 함수에서 렌더링이 한 번만 일어나므로 setSerachValue(e.target.value) 와 searchParams.set('serach', searchValue) 를 한 함수에 넣으면 searchValue 가 아직 바뀌기 전이라서 원하는 값이 쿼리 스트링에 반영되지 않음 / searchParams.set('search', e.target.value) 로 써야 함
- 컴포넌트가 렌더링 될 때 함수가 바로 실행되는 것이 아니라면 함수를 작성할 때 () => 이렇게 한 번 거쳐야 함
/ const menuTabOpen = () => {} 이렇게 쓰거나 함수가 실행되는 곳에서 onClick = {()=> moveTo} 이렇게 써야 함
- MAPPING_OBJ 객체의 속성인 컴포넌트 (Plants: <PlantsCate />, Materials: <MaterialsCate />, Search: <Search /> 에 props 를 넘겨주려면 (MAPPING_OBJ가 함수 외부에 있으므로) MAPPING_OBJ 를 렌더링하는 부분에서 MAPPING_OBJ 의 key 를 함수처럼 취급 / 자식 컴포넌트에 props 로 넘길 변수를 인자로 써주기
{MAPPING_OBJ[currentTab] && MAPPING_OBJ[currentTab](menuTablClose, closeBtn)} (MAPPING_OBJ 의 값이 있을 때!)
그리고 MAPPING_OBJ 에서 아래처럼 넘겨줘야 함
```
{
Plants: menuTabClose => <PlantsCate menuTabClose={menuTabClose} />,
Materials: menuTabClose => <MaterialsCate menuTabClose={menuTabClose} />,
Search: (menuTabClose, closeBtn) => (<Search menuTabClose={menuTabClose} closeBtn={closeBtn} />),
};
```
<br />

## :: 기타 질문 및 특이 사항
_- MenuList 모달창 구현 전이므로 레이아웃 확인을 위해 임시로 menulist 페이지를 만듦 (Nav의 메뉴 탭의 Search 를 누르면 menulist 페이지로 이동)_
<br />
